### PR TITLE
Update minimum required version of cocotb

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
         packages=find_packages("src"),
         package_dir={"": "src"},
         install_requires=[
-            "cocotb>1.4,<2.0"
+            "cocotb>=1.5.0.dev,<2.0"
         ],
         python_requires='>=3.5'
     )


### PR DESCRIPTION
Allows installation of the development version of cocotb 1.5.0, while the rule `>1.4.0` did not.