### PR TITLE
Set __version__ to 'dev' if no _version module found

### DIFF
--- a/src/cocotb_bus/__init__.py
+++ b/src/cocotb_bus/__init__.py
@@ -2,4 +2,7 @@
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from ._version import version as __version__  # noqa
+try:
+	from ._version import version as __version__  # noqa
+except ModuleNotFoundError:
+	__version__ = 'dev'


### PR DESCRIPTION
I tried installing `cocotb-bus` with:

```bash
pip install git+git://github.com/cocotb/cocotb-bus.git@a3e22f787ac1f63c84dcdcee7303d75d26c9f38f
```

but:

```python3
>>> import cocotb_bus
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/martijn/code/project/env/lib64/python3.6/site-packages/cocotb_bus/__init__.py", line 5, in <module>
    from ._version import version as __version__  # noqa
ModuleNotFoundError: No module named 'cocotb_bus._version'
```

I assume the packaging tooling includes this when publishing op PyPi. I'm not sure what to set it to, as I don't know what processes depend on the variable. The proposed patch sets it to a  "nonsense" value of `dev`.