### PR TITLE
Add build directories and files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# ignore files created during build
+build/
+src/cocotb_bus.egg-info/
+src/cocotb_bus/_version.py


### PR DESCRIPTION
Build results shouldn't be added to Git, thus add them to .gitignore to keep repository clean even after a build