### PR TITLE
Release v0.2.1

### DIFF
--- a/src/cocotb_bus/_version.py
+++ b/src/cocotb_bus/_version.py
@@ -1,1 +1,1 @@
-__version__ = "0.1.dev2"
+__version__ = "0.2.1"


### PR DESCRIPTION
Release v0.2.1.
* Removes setuptools_scm dependency

Uploaded to [TestPyPI](https://test.pypi.org/project/cocotb-bus/).