### PR TITLE
Case insensitive signal connection for optional signals.

### DIFF
--- a/src/cocotb_bus/bus.py
+++ b/src/cocotb_bus/bus.py
@@ -67,9 +67,9 @@ class Bus:
                 signame = name + bus_separator + sig_name
             else:
                 signame = sig_name
-
+            # Signal matching on optional attributes needs to be also case insensitive
             self._entity._log.debug("Signal name {}".format(signame))
-            if hasattr(entity, signame):
+            if self._caseInsensGetattr(entity, signame) is not None:
                 self._add_signal(attr_name, signame, array_idx, case_insensitive)
             else:
                 self._entity._log.debug("Ignoring optional missing signal "
@@ -79,6 +79,7 @@ class Bus:
         for a in dir(obj):
             if a.casefold() == attr.casefold():
                 return getattr(obj, a)
+        return None
 
     def _add_signal(self, attr_name, signame, array_idx=None, case_insensitive=True):
         self._entity._log.debug("Signal name {}, idx {}".format(signame, array_idx))

--- a/tests/test_cases/test_case_insensitive/Makefile
+++ b/tests/test_cases/test_case_insensitive/Makefile
@@ -1,0 +1,13 @@
+# Copyright cocotb contributors
+# Copyright (c) 2022 benycze
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+TOPLEVEL_LANG := verilog
+PWD=$(shell pwd)
+TOPLEVEL := case_insensitive
+VERILOG_SOURCES = $(PWD)/case_insensitive.v
+
+include $(shell cocotb-config --makefiles)/Makefile.sim
+
+MODULE = case_insensitive

--- a/tests/test_cases/test_case_insensitive/case_insensitive.py
+++ b/tests/test_cases/test_case_insensitive/case_insensitive.py
@@ -1,0 +1,99 @@
+# Copyright cocotb contributors
+# Copyright (c) 2022 benycze
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import cocotb
+import random
+from cocotb.clock import Clock
+from cocotb_bus.drivers import BusDriver
+from cocotb_bus.monitors import BusMonitor
+from cocotb.triggers import RisingEdge
+
+class TestTransaction:
+
+    def __init__(self, data, tmp):
+        self.data = data
+        self.tmp  = tmp
+
+    def __eq__(self, o):
+        if self.data != o.data:
+            return False
+        if self.tmp != o.tmp:
+            return False
+        return True
+    
+    def __str__(self):
+        return "[data={}, tmp={}]".format(self.data, self.tmp)
+
+class TestDriver(BusDriver):
+    # Test is using lower cases for signal ports. It should be mapped
+    # to uppercase port on entity
+    _signals = ["data", "valid"]
+    _optional_signals = ["tmp"]
+
+    def __init__(self, entity, name, clock, **kwargs):
+        BusDriver.__init__(self, entity, name, clock, **kwargs)
+        # Setup initial values
+        self.bus.valid.value = 0
+        self.bus.data.value  = 0
+        self.bus.tmp.value   = 0
+
+    async def _driver_send(self, transaction, sync=True):
+        clkedge = RisingEdge(self.clock)
+        if sync:
+            await clkedge
+
+        self.log.info("Sending {}".format(transaction))
+        self.bus.valid.value = 1
+        self.bus.data.value  = transaction.data
+        self.bus.tmp.value   = transaction.tmp
+
+        await clkedge
+        self.bus.valid.value = 0
+        self.bus.data.value  = 0
+        self.bus.tmp.value   = 0
+
+class TestMonitor(BusMonitor):
+    # Test is using lower cases for signal ports. It should be mapped
+    # to uppercase port on entity
+    _signals = ["data", "valid"]
+    _optional_signals = ["tmp"]
+
+    def __init__(self, entity, name, clock, **kwargs):
+        BusMonitor.__init__(self, entity, name, clock, **kwargs)
+        self.add_callback(self._get_result)
+        self.expected = []
+
+    async def _monitor_recv(self):
+        clkedge = RisingEdge(self.clock)
+        while True:
+            await clkedge
+            if not self.bus.valid.value:
+                continue
+            # Receive transaction and provide to _recv method
+            tr = TestTransaction(int(self.bus.data), int(self.bus.tmp))
+            self._recv(tr)
+
+    def _get_result(self, transaction):
+        self.log.info("Received transaction: {} ".format(str(transaction)))
+        exp = self.expected.pop(0)
+        assert exp == transaction, "Transaction {} and {} are not same.".format(str(exp), str(transaction))
+
+    def add_expected(self, transaction):
+        self.expected.append(transaction)
+
+@cocotb.test()
+async def test_case_insensitive(dut):
+    clock = Clock(dut.clk, 10, units="ns")
+    cocotb.fork(clock.start())
+    clkedge  = RisingEdge(dut.clk)
+    in_data  = TestDriver(dut, "in", dut.clk)
+    out_data = TestMonitor(dut, "in", dut.clk)
+    # Generate random amount of transactions
+    for i in range(0,20):
+        tr = TestTransaction(random.randint(0, 1), random.randint(0, 1))
+        out_data.add_expected(tr)
+        await in_data.send(tr)
+        await clkedge
+    assert len(out_data) == 0, "Some transactions are still available"

--- a/tests/test_cases/test_case_insensitive/case_insensitive.v
+++ b/tests/test_cases/test_case_insensitive/case_insensitive.v
@@ -1,0 +1,39 @@
+// Copyright cocotb contributors
+// Copyright (c) 2022 benycze
+// Licensed under the Revised BSD License, see LICENSE for details.
+// SPDX-License-Identifier: BSD-3-Clause
+
+// The following module is using mix of upper and lower cases
+// for port declarations
+module case_insensitive (
+      input    clk,
+      input    IN_DATA,
+      input    in_valid,
+      input    in_tmp,
+      output   out_data,
+      output   OUT_VALID,
+      output   OUT_TMP
+);
+
+reg tmp_data;
+reg tmp_valid;
+reg tmp_out;
+
+initial begin
+   tmp_data    = 1'b0;
+   tmp_valid   = 1'b0;
+   tmp_out     = 1'b0;
+end
+
+always @(posedge clk) begin
+   tmp_data  <= IN_DATA;
+   tmp_valid <= in_valid;
+   tmp_out   <= in_tmp;
+end
+
+assign out_data   = tmp_data;
+assign OUT_VALID  = tmp_valid;
+assign OUT_TMP    = tmp_out;
+
+endmodule
+


### PR DESCRIPTION
Hi all,

I was working with an extension and I had an issue with a matching of optional signals and entity ports. The original code isn't using a case-insensitive match and therefore I have fixed that for this case.

Feel free to merge the code, request changes or close it if the case insensitive match isn't a good feature here. :-)

Best,
Beny