### PR TITLE
Add reset to the internal variables of AvalonSTPkts monitor

### DIFF
--- a/src/cocotb_bus/monitors/avalon.py
+++ b/src/cocotb_bus/monitors/avalon.py
@@ -142,6 +142,10 @@ class AvalonSTPkts(BusMonitor):
             await clkedge
 
             if self.in_reset:
+                pkt = b""
+                in_pkt = False
+                invalid_cyclecount = 0
+                channel = None
                 continue
 
             if valid():


### PR DESCRIPTION
This PR adds a reset of the internal variables of AvalonSTPkts monitor. It prevents the `Duplicate start-of-packet received ...` error when reset occurs in the middle of a transaction.