### PR TITLE
Attempt common case transformations first before calling dir() as a workaround for a bug in Verilator

### DIFF
--- a/src/cocotb_bus/bus.py
+++ b/src/cocotb_bus/bus.py
@@ -7,6 +7,10 @@
 """Common bus related functionality.
 A bus is simply defined as a collection of signals.
 """
+
+import warnings
+
+import cocotb
 from cocotb.handle import _AssignmentResult
 
 def _build_sig_attr_dict(signals):
@@ -80,6 +84,12 @@ class Bus:
         for a in (attr, attr.upper(), attr.lower()):
             if hasattr(obj, a):
                 return getattr(obj, a)
+        if cocotb.SIM_NAME.lower().startswith("verilator"):
+            warnings.warn(
+                "Using dir() for case-insensitive matching;"
+                "this may trigger a known Verilator bug",
+                RuntimeWarning,
+            )
         for a in dir(obj):
             if a.casefold() == attr.casefold():
                 return getattr(obj, a)

--- a/src/cocotb_bus/bus.py
+++ b/src/cocotb_bus/bus.py
@@ -76,6 +76,10 @@ class Bus:
                                         "%s on bus %s" % (sig_name, name))
 
     def _caseInsensGetattr(self, obj, attr):
+        # dir breaks verilator, so avoid calling it if possible
+        for a in (attr, attr.upper(), attr.lower()):
+            if hasattr(obj, a):
+                return getattr(obj, a)
         for a in dir(obj):
             if a.casefold() == attr.casefold():
                 return getattr(obj, a)


### PR DESCRIPTION
Version 5.006 of Verilator has a bug related to enumerating the hierarchy.  After calling `dir()`, writable signal handles cannot be created by cocotb.  Since `Bus` calls `dir()` as part of the case-insensitive name matching, this breaks every testbench that uses `Bus` when running on Verilator.  So, as a workaround, we can try to avoid calling `dir()` by attempting some common case transformations first (as-is, all lowercase, and all uppercase) before falling back on `dir()` + `casefold`.  (And possibly trying "as-is" before case-folding might be a good idea anyway)

Also, I am not aware of an issue related to this on the Verilator issue tracker.  Hard to fix bugs if they aren't reported, so does anyone know if this issue was ever reported to Verilator?  And if so, is there a link to the issue there?

Additionally, is there anything to be said about adding a warning about this if `dir()` does end up getting called when running under verilator, to avoid hours of head-scratching?

See also:

- https://github.com/cocotb/cocotb/issues/3206
- https://github.com/cocotb/cocotb/issues/2244