### PR TITLE
Improve docs; replace TestFailure and hexdiffs usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 
 [![PyPI](https://img.shields.io/pypi/dm/cocotb-bus.svg?label=PyPI%20downloads)](https://pypi.org/project/cocotb-bus/)
 
-The new home of the [cocotb](https://github.com/cocotb) project's pre-packaged testbenching tools and reusable bus interfaces.
+**cocotb-bus** contains pre-packaged testbenching tools and
+reusable bus interfaces for [cocotb](https://cocotb.org).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -48,10 +48,10 @@ extensions = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
+    "cocotb": ("https://docs.cocotb.org/en/latest/", None),
     "ghdl": ("https://ghdl.github.io/ghdl", None),
     "scapy": ("https://scapy.readthedocs.io/en/latest", None),
     "pytest": ("https://docs.pytest.org/en/latest/", None),
-    #"cocotb": ("https://docs.cocotb.org/en/latest/", None),
 }
 
 # Github repo
@@ -71,7 +71,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "cocotb-bus"
-copyright = "2014-{0}, cocotb contributors".format(datetime.datetime.now().year)
+copyright = "2014-{0}, cocotb-bus contributors".format(datetime.datetime.now().year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,11 +15,14 @@ Welcome to cocotb-bus's documentation!
 What is cocotb-bus?
 *******************
 
-**cocotb-bus** is:
+**cocotb-bus** consists of pre-packaged testbenching tools and reusable bus interfaces
+for https://cocotb.org.
 
-* A set of Driver's & Monitor base classes to assist in creating cocotb VIP's.
-* An implementation of scoreboard class for cocotb.
-* Sample implementation of Protocol Bus drivers using these classes.
+A bit more detailed, cocotb-bus is:
+
+* A set of Driver & Monitor base classes to assist in creating cocotb VIPs.
+* An implementation of a scoreboard class for cocotb.
+* Sample implementation of protocol bus drivers using these classes.
 
 
 .. toctree::
@@ -44,13 +47,13 @@ What is cocotb-bus?
    - no distractions
 
 ..
-.. toctree::
-   :maxdepth: 1
-   :caption: Tutorials
-   :name: tutorials
-   :hidden:
+   .. toctree::
+      :maxdepth: 1
+      :caption: Tutorials
+      :name: tutorials
+      :hidden:
 
-   examples
+      examples
 
 
 ..
@@ -66,18 +69,18 @@ What is cocotb-bus?
    - good naming
 
 ..
-.. toctree::
-   :maxdepth: 1
-   :caption: How-to Guides
-   :name: howto_guides
-   :hidden:
+   .. toctree::
+      :maxdepth: 1
+      :caption: How-to Guides
+      :name: howto_guides
+      :hidden:
 
-   writing_testbenches
-   runner
-   coroutines
-   triggers
-   custom_flows
-   rotating_logger
+      writing_testbenches
+      runner
+      coroutines
+      triggers
+      custom_flows
+      rotating_logger
 
 .. todo::
    - Howto use the baseclasses to create VIP
@@ -95,14 +98,14 @@ What is cocotb-bus?
    - no instruction or technical description
 
 ..
-.. toctree::
-   :maxdepth: 1
-   :caption: Key topics
-   :name: key_topics
-   :hidden:
+   .. toctree::
+      :maxdepth: 1
+      :caption: Key topics
+      :name: key_topics
+      :hidden:
 
-   install_devel
-   troubleshooting
+      install_devel
+      troubleshooting
 
 
 
@@ -124,18 +127,18 @@ What is cocotb-bus?
 
    Python Code Library Reference <library_reference>
 
-..
 .. toctree::
    :maxdepth: 1
    :caption: Development & Community
    :name: development_community
    :hidden:
 
-   roadmap
-   contributors
    release_notes
-   further_resources
 ..
+      roadmap
+      contributors
+      further_resources
+
 .. todo::
    - Add "Join us online" and "Contributing"
    - In Contributing, add explanation on how to provide a PR, how to test existing PRs, etc.
@@ -148,5 +151,6 @@ What is cocotb-bus?
    :hidden:
 
    Classes, Methods, Variables etc. <genindex>
-   Python Modules <py-modindex>
    glossary
+..
+   Python Modules <py-modindex>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,6 +1,6 @@
-######################################
+**************************************
 Welcome to cocotb-bus's documentation!
-######################################
+**************************************
 
 ..
    This documentation tries to follow https://www.divio.com/blog/documentation/ (Daniele Procida)
@@ -11,9 +11,8 @@ Welcome to cocotb-bus's documentation!
 
    See also https://github.com/cocotb/cocotb/wiki/Howto:-Writing-Documentation
 
-*******************
 What is cocotb-bus?
-*******************
+===================
 
 **cocotb-bus** consists of pre-packaged testbenching tools and reusable bus interfaces
 for https://cocotb.org.
@@ -23,6 +22,14 @@ A bit more detailed, cocotb-bus is:
 * A set of Driver & Monitor base classes to assist in creating cocotb VIPs.
 * An implementation of a scoreboard class for cocotb.
 * Sample implementation of protocol bus drivers using these classes.
+
+Dependencies
+------------
+
+In addition to what cocotb itself requires,
+cocotb-bus has a dependency on ``scapy`` (https://scapy.readthedocs.io/)
+for its :func:`scapy.utils.hexdump` and :func:`scapy.utils.hexdiff` functions
+used in the :mod:`.scoreboard`.
 
 
 .. toctree::

--- a/docs/source/library_reference.rst
+++ b/docs/source/library_reference.rst
@@ -2,7 +2,7 @@
 Library Reference
 *****************
 
-.. spelling::
+.. spelling:word-list::
    AXIProtocolError
    BusDriver
    De
@@ -74,3 +74,107 @@ Scoreboard
     :show-inheritance:
     :synopsis: Class for scoreboards.
 
+
+Implemented Testbench Structures
+================================
+
+Drivers
+-------
+
+AMBA
+^^^^
+
+Advanced Microcontroller Bus Architecture.
+
+.. currentmodule:: cocotb_bus.drivers.amba
+
+.. autoclass:: AXI4Master
+    :members:
+    :member-order: bysource
+
+.. autoclass:: AXI4LiteMaster
+    :members:
+    :member-order: bysource
+
+.. autoclass:: AXI4Slave
+    :members:
+    :member-order: bysource
+
+
+Avalon
+^^^^^^
+
+.. currentmodule:: cocotb_bus.drivers.avalon
+
+.. autoclass:: AvalonMM
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+.. autoclass:: AvalonMaster
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+.. autoclass:: AvalonMemory
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+.. autoclass:: AvalonST
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+.. autoclass:: AvalonSTPkts
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+
+OPB
+^^^
+
+.. currentmodule:: cocotb_bus.drivers.opb
+
+.. autoclass:: OPBMaster
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+
+XGMII
+^^^^^
+
+.. currentmodule:: cocotb_bus.drivers.xgmii
+
+.. autoclass:: XGMII
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+Monitors
+--------
+
+Avalon
+^^^^^^
+
+.. currentmodule:: cocotb_bus.monitors.avalon
+
+.. autoclass:: AvalonST
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+.. autoclass:: AvalonSTPkts
+    :members:
+    :member-order: bysource
+    :show-inheritance:
+
+XGMII
+^^^^^
+
+.. autoclass:: cocotb_bus.monitors.xgmii.XGMII
+    :members:
+    :member-order: bysource
+    :show-inheritance:

--- a/docs/source/newsfragments/68.change.rst
+++ b/docs/source/newsfragments/68.change.rst
@@ -1,0 +1,1 @@
+cocotb-bus now depends on ``scapy`` (https://scapy.readthedocs.io/) for its :func:`scapy.utils.hexdump` and :func:`scapy.utils.hexdiff` functions used in the :mod:`.scoreboard`.

--- a/docs/source/newsfragments/README.rst
+++ b/docs/source/newsfragments/README.rst
@@ -1,0 +1,56 @@
+:orphan:
+
+*********************
+Writing Release Notes
+*********************
+
+We are using `towncrier <https://pypi.org/project/towncrier/>`_ to handle
+our release notes, and this directory contains the input for it -
+"news fragments" which are short files that contain a small
+**ReST**-formatted text that will be added to the next version's
+Release Notes page.
+
+Each file should be named like ``<ISSUE_OR_PR>.<TYPE>.rst``,
+where ``<ISSUE_OR_PR>`` is an issue or a pull request number -
+whatever is most useful to link to,
+and ``<TYPE>`` is one of:
+
+* ``feature``: New user-facing feature.
+* ``bugfix``: A bug fix.
+* ``doc``: Documentation improvement.
+* ``removal``: Deprecation or removal of public API or behavior.
+* ``change``: A change in public API or behavior.
+
+In that file, make sure to use full sentences with correct case and punctuation,
+and do not use a bullet point at the beginning of the file.
+Each fragment file should be a single piece of news on a single line;
+multi-line files will not render correctly.
+In cases where there is more than one piece of news for a pull request,
+split the news into 2 fragments (see below for details on how to do that).
+Use Sphinx references (see https://sphinx-tutorial.readthedocs.io/cheatsheet/)
+if you refer to added classes, methods etc.
+
+Additional newsfragments of the same ``<TYPE>`` for a single ``<ISSUE_OR_PR>`` are
+supported, using the name format ``<ISSUE_OR_PR>.<TYPE>.<#>.rst``.
+
+Example:
+
+* ``<ISSUE_OR_PR>.bugfix.rst``
+* ``<ISSUE_OR_PR>.bugfix.1.rst``
+
+An example file could consist of the content between the marks:
+
+--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<--8<
+Summary of a new feature.
+
+This is a second paragraph.
+-->8-->8-->8-->8-->8-->8-->8-->8-->8-->8-->8-->8-->8-->8-->8-->8-->8-->8-->8-->8
+
+Note that the last paragraph should be a normal sentence and not e.g. code,
+because the issue number is appended there.
+
+Towncrier automatically assembles a list of unreleased changes when building Sphinx,
+meaning your notes will be visible in the documentation immediately after merging.
+When performing a release, ``towncrier`` should be run independently
+(in cocotb-bus's root directory),
+which will delete all the merged newsfragments, and create new commits.

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,0 +1,12 @@
+*************
+Release Notes
+*************
+
+.. spelling:word-list::
+   dev
+
+All releases are available from the `GitHub Releases Page <https://github.com/cocotb/cocotb-bus/releases>`_.
+
+.. include:: master-notes.rst
+
+.. towncrier release notes start

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,19 +8,19 @@ def tests(session):
     session.run("make", external=True)
 
 
+def create_env_for_docs_build(session: nox.Session) -> None:
+    session.run("pip", "install", "-r", "docs/requirements.txt")
+
+
 @nox.session
-def doc(session: nox.Session) -> None:
+def docs(session: nox.Session) -> None:
+    """Invoke sphinx-build to build the HTML docs"""
     create_env_for_docs_build(session)
     session.run("pip", "install", ".")
     outdir = session.cache_dir / "docs_out"
-    session.run("sphinx-build", "./docs/source",
-                str(outdir), "--color", "-b", "html")
+    session.run("sphinx-build", "./docs/source", str(outdir), "--color", "-b", "html")
     index = (outdir / "index.html").resolve().as_uri()
     session.log(f"Documentation is available at {index}")
-
-
-def create_env_for_docs_build(session: nox.Session) -> None:
-    session.run("pip", "install", "-r", "docs/requirements.txt")
 
 
 @nox.session
@@ -36,10 +36,10 @@ def docs_preview(session: nox.Session) -> None:
         # Ignore directories which cause a rebuild loop.
         "--ignore",
         "*/source/master-notes.rst",
-        # Also watch the cocotb source directory to rebuild the API docs on
-        # changes to cocotb code.
+        # Also watch the cocotb_bus source directory to rebuild the API docs on
+        # changes to cocotb_bus code.
         "--watch",
-        "cocotb_bus",
+        "src/cocotb_bus",
         "./docs/source",
         str(outdir),
     )
@@ -47,7 +47,7 @@ def docs_preview(session: nox.Session) -> None:
 
 @nox.session
 def docs_linkcheck(session: nox.Session) -> None:
-    """invoke sphinx-build to linkcheck the docs"""
+    """Invoke sphinx-build to linkcheck the docs"""
     create_env_for_docs_build(session)
     session.run("pip", "install", ".")
     outdir = session.cache_dir / "docs_out"
@@ -63,7 +63,7 @@ def docs_linkcheck(session: nox.Session) -> None:
 
 @nox.session
 def docs_spelling(session: nox.Session) -> None:
-    """invoke sphinx-build to spellcheck the docs"""
+    """Invoke sphinx-build to spellcheck the docs"""
     create_env_for_docs_build(session)
     session.run("pip", "install", ".")
     outdir = session.cache_dir / "docs_out"

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ if __name__ == "__main__":
         packages=find_packages("src"),
         package_dir={"": "src"},
         install_requires=[
-            "cocotb>=1.5.0.dev,<2.0"
+            "cocotb>=1.5.0.dev,<2.0",
+            "scapy",
         ],
         python_requires='>=3.5'
     )

--- a/src/cocotb_bus/bus.py
+++ b/src/cocotb_bus/bus.py
@@ -19,7 +19,7 @@ def _build_sig_attr_dict(signals):
 class Bus:
     """Wraps up a collection of signals.
 
-    Assumes we have a set of signals/nets named ``entity.<bus_name><separator><signal>``.
+    Assumes we have a set of signals/nets named ``entity.<bus_name><bus_separator><signal>``.
 
     For example a bus ``stream_in`` with signals ``valid`` and ``data`` is assumed
     to be named ``dut.stream_in_valid`` and ``dut.stream_in_data`` (with
@@ -32,7 +32,7 @@ class Bus:
     def __init__(self, entity, name, signals, optional_signals=[], bus_separator="_", case_insensitive=True, array_idx=None):
         """
         Args:
-            entity (SimHandle): :any:`SimHandle` instance to the entity containing the bus.
+            entity (SimHandle): :class:`SimHandle` instance to the entity containing the bus.
             name (str): Name of the bus. ``None`` for a nameless bus, e.g. bus-signals
                 in an interface or a ``modport`` (untested on ``struct``/``record``,
                 but could work here as well).


### PR DESCRIPTION
I lumped the code updates for `TestFailure` conversion to assertions and replacing `cocotb.utils.hexdiffs` to `scapy.utils.hexdiff` together with the actual documentation changes
to not require a pull request chain.

Refs #65, the "enable cocotb intersphinx again" item.