### PR TITLE
Fix waves issue on MacOS caused by dirs(). Should be vars().

### DIFF
--- a/src/cocotb_bus/bus.py
+++ b/src/cocotb_bus/bus.py
@@ -76,7 +76,7 @@ class Bus:
                                         "%s on bus %s" % (sig_name, name))
 
     def _caseInsensGetattr(self, obj, attr):
-        for a in dir(obj):
+        for a in vars(obj):
             if a.casefold() == attr.casefold():
                 return getattr(obj, a)
         return None


### PR DESCRIPTION
Fixes issue described in https://github.com/cocotb/cocotb-bus/issues/72