### PR TITLE
Brush up CI

### DIFF
--- a/.github/workflows/pypi-upload.yml
+++ b/.github/workflows/pypi-upload.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     name: deploy
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
       with:
         # To generate a valid version number setuptools_scm needs sufficient
         # git history.
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: "3.9"
     - name: Install pypa/build

--- a/.github/workflows/pypi-upload.yml
+++ b/.github/workflows/pypi-upload.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     name: deploy
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # To generate a valid version number setuptools_scm needs sufficient
         # git history.
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.12"
     - name: Install pypa/build
       run: >-
         python -m

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,11 @@
 # Copyright cocotb contributors
 # Licensed under the Revised BSD License, see LICENSE for details.
 # SPDX-License-Identifier: BSD-3-Clause
+
 name: Tests
 
 on:
   push:
-    # branches:
-    #   - master
-    #   - 'stable/**'
   pull_request:
     branches:
       - master
@@ -23,7 +21,7 @@ jobs:
     if:
       github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
-    name: ${{ matrix.extra_name }}${{ matrix.sim }} (${{ matrix.sim-version }}) | ${{ matrix.os }} | Python ${{ matrix.python-version }} ${{ matrix.may_fail && '| May Fail' || '' }}
+    name: ${{ matrix.extra_name }}cocotb ${{matrix.cocotb-version }} | ${{ matrix.sim }} (${{ matrix.sim-version }}) | ${{ matrix.os }} | Python ${{ matrix.python-version }} ${{ matrix.may_fail && '| May Fail' || '' }}
     runs-on: ${{ matrix.os }}
     env:
       SIM: ${{ matrix.sim }}
@@ -32,15 +30,18 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6", "3.12"]
+        # NOTE: align with versions in noxfile.py:
+        cocotb-version: ["1.6.0", "1.8.1"]
         include:
         - sim: icarus
           sim-version: apt
-          # python-version: "3.6"
           lang: verilog
           os: ubuntu-20.04
+    timeout-minutes: 10
+
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install cocotb requirements
@@ -48,7 +49,7 @@ jobs:
         DEBIAN_FRONTEND: noninteractive
       run: |
         sudo apt-get update
-        sudo apt-get install --yes g++ make
+        sudo apt-get install --yes --no-install-recommends g++ make
     - name: Set up Icarus (apt)
       if: matrix.sim == 'icarus' && matrix.sim-version == 'apt'
       env:
@@ -57,8 +58,10 @@ jobs:
         sudo apt-get install --yes --no-install-recommends iverilog
     - name: Install testing requirements
       run: |
-        pip install nox
+        python -m pip install nox
     - name: Run tests
+      env:
+        COCOTB_ANSI_OUTPUT: 1
       continue-on-error: ${{ matrix.may_fail || false }}
       run: |
-        nox -e tests
+        nox --session "tests(cocotb='${{ matrix.cocotb-version }}')"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.12"]
         # NOTE: align with versions in noxfile.py:
-        cocotb-version: ["1.6.0", "1.8.1"]
+        cocotb-version: ["1.6.0", "1.9.0"]
         include:
         - sim: icarus
           sim-version: apt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@
 name: Tests
 
 on:
-  push:
   pull_request:
     branches:
       - master
@@ -17,10 +16,6 @@ concurrency:
 
 jobs:
   tests:
-    # Run on external PRs, but not on internal PRs (since that would duplicate push-triggered runs)
-    if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
-
     name: ${{ matrix.extra_name }}cocotb ${{matrix.cocotb-version }} | ${{ matrix.sim }} (${{ matrix.sim-version }}) | ${{ matrix.os }} | Python ${{ matrix.python-version }} ${{ matrix.may_fail && '| May Fail' || '' }}
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,21 +5,29 @@ name: Tests
 
 on:
   push:
-    branches:
-      - master
-      - 'stable/**'
+    # branches:
+    #   - master
+    #   - 'stable/**'
   pull_request:
     branches:
       - master
       - 'stable/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
-    name: ${{matrix.extra_name}}${{matrix.sim}} (${{matrix.sim-version}}) | ${{matrix.os}} | Python ${{matrix.python-version}} ${{matrix.may_fail && '| May Fail' || ''}}
-    runs-on: ${{matrix.os}}
+    # Run on external PRs, but not on internal PRs (since that would duplicate push-triggered runs)
+    if:
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+
+    name: ${{ matrix.extra_name }}${{ matrix.sim }} (${{ matrix.sim-version }}) | ${{ matrix.os }} | Python ${{ matrix.python-version }} ${{ matrix.may_fail && '| May Fail' || '' }}
+    runs-on: ${{ matrix.os }}
     env:
-      SIM: ${{matrix.sim}}
-      TOPLEVEL_LANG: ${{matrix.lang}}
+      SIM: ${{ matrix.sim }}
+      TOPLEVEL_LANG: ${{ matrix.lang }}
     strategy:
       fail-fast: false
       matrix:
@@ -27,13 +35,14 @@ jobs:
         include:
         - sim: icarus
           sim-version: apt
+          # python-version: "3.6"
           lang: verilog
-          os: ubuntu-22.04
+          os: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: ${{matrix.python-version}}
+        python-version: ${{ matrix.python-version }}
     - name: Install cocotb requirements
       env:
         DEBIAN_FRONTEND: noninteractive
@@ -45,11 +54,11 @@ jobs:
       env:
         DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt-get install --yes iverilog
+        sudo apt-get install --yes --no-install-recommends iverilog
     - name: Install testing requirements
       run: |
         pip install nox
     - name: Run tests
-      continue-on-error: ${{matrix.may_fail || false}}
+      continue-on-error: ${{ matrix.may_fail || false }}
       run: |
         nox -e tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,24 +23,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version: ["3.6", "3.12"]
         include:
         - sim: icarus
           sim-version: apt
           lang: verilog
-          python-version: 3.6
-          os: ubuntu-20.04
+          os: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{matrix.python-version}}
     - name: Install cocotb requirements
+      env:
+        DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt install -y g++ make
+        sudo apt-get update
+        sudo apt-get install --yes g++ make
     - name: Set up Icarus (apt)
       if: matrix.sim == 'icarus' && matrix.sim-version == 'apt'
+      env:
+        DEBIAN_FRONTEND: noninteractive
       run: |
-        sudo apt install -y iverilog
+        sudo apt-get install --yes iverilog
     - name: Install testing requirements
       run: |
         pip install nox

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,8 +2,9 @@ import nox
 
 
 @nox.session
-def tests(session):
-    session.install("pytest", "coverage")
+@nox.parametrize("cocotb", ["1.6.0", "1.8.1"])
+def tests(session, cocotb):
+    session.install("pytest", "coverage", f"cocotb=={cocotb}")
     session.install(".")
     session.run("make", external=True)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import nox
 
 
 @nox.session
-@nox.parametrize("cocotb", ["1.6.0", "1.8.1"])
+@nox.parametrize("cocotb", ["1.6.0", "1.9.0"])
 def tests(session, cocotb):
     session.install("pytest", "coverage", f"cocotb=={cocotb}")
     session.install(".")

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ if __name__ == "__main__":
         packages=find_packages("src"),
         package_dir={"": "src"},
         install_requires=[
-            "cocotb>=1.5.0.dev,<2.0",
+            "cocotb>=1.6.0,<2.0",
             "scapy",
         ],
-        python_requires='>=3.5'
+        python_requires='>=3.6'
     )

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,8 +26,9 @@
 ###############################################################################
 
 # Do not fail on DeprecationWarning caused by virtualenv, which might come from
-# the distutils or site modules.
-export PYTHONWARNINGS = error,ignore::DeprecationWarning:distutils,ignore::DeprecationWarning:site
+# the site module.
+# Do not fail on DeprecationWarning caused by attrs dropping 3.6 support
+export PYTHONWARNINGS = error,ignore::DeprecationWarning:site,always::FutureWarning:cocotb.scheduler,ignore::DeprecationWarning:attr
 
 REGRESSIONS :=  $(shell ls test_cases/)
 


### PR DESCRIPTION
Make CI setup work again (but not actually pass, because of #62).

Do not run CI on both push and PR.
Use latest version of actions.
Iterate over oldest and newest supported Python versions.
Iterate over oldest and newest supported cocotb versions.
Use color output for cocotb tests.