### PR TITLE
Remove deprecated cocotb functionality

### DIFF
--- a/examples/axi_lite_slave/tests/test_axi_lite_slave.py
+++ b/examples/axi_lite_slave/tests/test_axi_lite_slave.py
@@ -40,7 +40,8 @@ async def write_address_0(dut):
     await axim.write(ADDRESS, DATA)
     await Timer(CLK_PERIOD_NS * 10, units='ns')
 
-    value = dut.dut.r_temp_0
+    value = dut.dut.r_temp_0.value
+
     assert value == DATA, ("Register at address 0x%08X should have been "
                            "0x%08X but was 0x%08X" % (ADDRESS, DATA, int(value)))
     dut._log.info("Write 0x%08X to address 0x%08X" % (int(value), ADDRESS))
@@ -110,7 +111,7 @@ async def write_and_read(dut):
     value = await axim.read(ADDRESS)
     await Timer(CLK_PERIOD_NS * 10, units='ns')
 
-    value = dut.dut.r_temp_0
+    value = dut.dut.r_temp_0.value
     assert value == DATA, ("Register at address 0x%08X should have been "
                            "0x%08X but was 0x%08X" % (ADDRESS, DATA, int(value)))
     dut._log.info("Write 0x%08X to address 0x%08X" % (int(value), ADDRESS))

--- a/examples/dff/tests/dff_cocotb.py
+++ b/examples/dff/tests/dff_cocotb.py
@@ -32,8 +32,8 @@ import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import ReadOnly, RisingEdge
 from cocotb.binary import BinaryValue
-from cocotb.regression import TestFactory
 
+from cocotb_bus.compat import TestFactory
 from cocotb_bus.monitors import Monitor
 from cocotb_bus.drivers import BitDriver
 from cocotb_bus.scoreboard import Scoreboard

--- a/examples/endian_swapper/hal_tests/test_endian_swapper_hal.py
+++ b/examples/endian_swapper/hal_tests/test_endian_swapper_hal.py
@@ -78,7 +78,7 @@ async def initial_hal_test(dut, debug=True):
     state = hal.endian_swapper_init(0)
 
     # Check the actual value
-    assert not dut.byteswapping.value, (
+    assert str(dut.byteswapping.value) != '1', (
         "Byteswapping is enabled but haven't configured DUT"
     )
 
@@ -86,7 +86,7 @@ async def initial_hal_test(dut, debug=True):
 
     await ReadOnly()
 
-    assert dut.byteswapping.value, (
+    assert str(dut.byteswapping.value) == '1', (
         "Byteswapping wasn't enabled after calling endian_swapper_enable"
     )
 

--- a/examples/endian_swapper/hal_tests/test_endian_swapper_hal.py
+++ b/examples/endian_swapper/hal_tests/test_endian_swapper_hal.py
@@ -29,7 +29,6 @@ import logging
 import cocotb
 from cocotb.triggers import RisingEdge, Timer, ReadOnly
 from cocotb.clock import Clock
-from cocotb.result import TestFailure
 from cocotb_bus.drivers.avalon import AvalonMaster
 
 import hal
@@ -79,15 +78,16 @@ async def initial_hal_test(dut, debug=True):
     state = hal.endian_swapper_init(0)
 
     # Check the actual value
-    if dut.byteswapping.value:
-        raise TestFailure("Byteswapping is enabled but haven't configured DUT")
+    assert not dut.byteswapping.value, (
+        "Byteswapping is enabled but haven't configured DUT"
+    )
 
     await cocotb.external(hal.endian_swapper_enable)(state)
 
     await ReadOnly()
 
-    if not dut.byteswapping.value:
-        raise TestFailure("Byteswapping wasn't enabled after calling "
-                          "endian_swapper_enable")
+    assert dut.byteswapping.value, (
+        "Byteswapping wasn't enabled after calling endian_swapper_enable"
+    )
 
     dut._log.info("HAL call endian_swapper_enable successfully enabled the DUT")

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -138,7 +138,7 @@ async def stream_out_config_setter(dut, stream_out, stream_in):
     while True:
         await edge
         await ro
-        if dut.byteswapping.value:
+        if str(dut.byteswapping.value) == '1':
             stream_out.config['firstSymbolInHighOrderBits'] = \
                 not stream_in.config['firstSymbolInHighOrderBits']
         else:
@@ -218,7 +218,7 @@ async def run_test(dut, data_in=None, config_coroutine=None, idle_inserter=None,
     # Wait at least 2 cycles where output ready is low before ending the test
     for i in range(2):
         await RisingEdge(dut.clk)
-        while not dut.stream_out_ready.value:
+        while str(dut.stream_out_ready.value) != '1':
             await RisingEdge(dut.clk)
 
     pkt_count = await tb.csr.read(1)

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -35,7 +35,7 @@ import cocotb
 
 from cocotb.clock import Clock
 from cocotb.triggers import Timer, RisingEdge, ReadOnly
-from cocotb.regression import TestFactory
+from cocotb_bus.compat import TestFactory
 from cocotb_bus.drivers import BitDriver
 from cocotb_bus.drivers.avalon import AvalonSTPkts as AvalonSTDriver
 from cocotb_bus.drivers.avalon import AvalonMaster

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -251,24 +251,3 @@ factory.add_option("idle_inserter",
 factory.add_option("backpressure_inserter",
                    [None, wave, intermittent_single_cycles, random_50_percent])
 factory.generate_tests()
-
-import cocotb.wavedrom
-
-
-@cocotb.test()
-async def wavedrom_test(dut):
-    """
-    Generate a JSON wavedrom diagram of a trace and save it to wavedrom.json
-    """
-    cocotb.start_soon(Clock(dut.clk, 10, units='ns').start())
-    await RisingEdge(dut.clk)
-    tb = EndianSwapperTB(dut)
-    await tb.reset()
-
-    with cocotb.wavedrom.trace(dut.reset_n, tb.csr.bus, clk=dut.clk) as waves:
-        await RisingEdge(dut.clk)
-        await tb.csr.read(0)
-        await RisingEdge(dut.clk)
-        await RisingEdge(dut.clk)
-        dut._log.info(waves.dumpj(header={'text':'WaveDrom example', 'tick':0}))
-        waves.write('wavedrom.json', header={'tick':0}, config={'hscale':3})

--- a/examples/mean/tests/test_mean.py
+++ b/examples/mean/tests/test_mean.py
@@ -25,7 +25,7 @@ class StreamBusMonitor(BusMonitor):
         while True:
             await RisingEdge(self.clock)
             await ReadOnly()
-            if self.bus.valid.value:
+            if str(self.bus.valid.value) == '1':
                 self._recv(int(self.bus.data.value))
 
 

--- a/src/cocotb_bus/compat.py
+++ b/src/cocotb_bus/compat.py
@@ -15,8 +15,17 @@ def TestFactory(*args, **kwargs):
         return cocotb.regression.TestFactory(*args, **kwargs)
 
 
-def coroutine(f):
-    if parse_version(cocotb.__version__) > parse_version("2.dev0"):
+if parse_version(cocotb.__version__) > parse_version("2.dev0"):
+    def set_event(event, data):
+        event.data = data
+        event.set()
+
+    def coroutine(f):
         return f
 
-    return cocotb.coroutine(f)
+else:
+    def set_event(event, data):
+        event.set(data)
+
+    def coroutine(f):
+        return cocotb.coroutine(f)

--- a/src/cocotb_bus/compat.py
+++ b/src/cocotb_bus/compat.py
@@ -4,7 +4,15 @@
 
 
 from packaging.version import parse as parse_version
+import warnings
+
 import cocotb
+
+def TestFactory(*args, **kwargs):
+    with warnings.catch_warnings():
+        # TestFactory has been deprecated in v2.0 and there's no migration path in v1.x
+        warnings.simplefilter("ignore")
+        return cocotb.regression.TestFactory(*args, **kwargs)
 
 
 def coroutine(f):

--- a/src/cocotb_bus/compat.py
+++ b/src/cocotb_bus/compat.py
@@ -1,0 +1,14 @@
+# Copyright cocotb contributors
+# Licensed under the Revised BSD License, see LICENSE for details.
+# SPDX-License-Identifier: BSD-3-Clause
+
+
+from packaging.version import parse as parse_version
+import cocotb
+
+
+def coroutine(f):
+    if parse_version(cocotb.__version__) > parse_version("2.dev0"):
+        return f
+
+    return cocotb.coroutine(f)

--- a/src/cocotb_bus/drivers/__init__.py
+++ b/src/cocotb_bus/drivers/__init__.py
@@ -7,13 +7,13 @@
 """Set of common driver base classes."""
 
 from collections import deque
+import logging
 from typing import Iterable, Tuple, Any, Optional, Callable
 
 import cocotb
 from cocotb.decorators import coroutine
 from cocotb.triggers import (Event, RisingEdge, ReadOnly, NextTimeStep,
                              Edge)
-from cocotb.log import SimLog
 from cocotb.handle import SimHandleBase
 
 from cocotb_bus.bus import Bus
@@ -86,7 +86,7 @@ class Driver:
 
         # Sub-classes may already set up logging
         if not hasattr(self, "log"):
-            self.log = SimLog("cocotb.driver.%s" % (type(self).__qualname__))
+            self.log = logging.getLogger("cocotb.driver.%s" % (type(self).__qualname__))
 
         # Create an independent coroutine which can send stuff
         self._thread = cocotb.start_soon(self._send_thread())
@@ -228,7 +228,7 @@ class BusDriver(Driver):
     def __init__(self, entity: SimHandleBase, name: Optional[str], clock: SimHandleBase, **kwargs: Any):
         index = kwargs.get("array_idx", None)
 
-        self.log = SimLog("cocotb.%s.%s" % (entity._name, name))
+        self.log = logging.getLogger("cocotb.%s.%s" % (entity._name, name))
         Driver.__init__(self)
         self.entity = entity
         self.clock = clock

--- a/src/cocotb_bus/drivers/__init__.py
+++ b/src/cocotb_bus/drivers/__init__.py
@@ -11,12 +11,12 @@ import logging
 from typing import Iterable, Tuple, Any, Optional, Callable
 
 import cocotb
-from cocotb.decorators import coroutine
 from cocotb.triggers import (Event, RisingEdge, ReadOnly, NextTimeStep,
                              Edge)
 from cocotb.handle import SimHandleBase
 
 from cocotb_bus.bus import Bus
+from cocotb_bus.compat import coroutine
 
 
 class BitDriver:

--- a/src/cocotb_bus/drivers/amba.py
+++ b/src/cocotb_bus/drivers/amba.py
@@ -163,7 +163,7 @@ class AXI4Master(BusDriver):
             # Wait until acknowledged
             while True:
                 await ReadOnly()
-                if self.bus.AWREADY.value:
+                if str(self.bus.AWREADY.value) == '1':
                     break
                 await RisingEdge(self.clock)
             await RisingEdge(self.clock)
@@ -239,7 +239,7 @@ class AXI4Master(BusDriver):
 
                 while True:
                     await RisingEdge(self.clock)
-                    if self.bus.WREADY.value:
+                    if str(self.bus.WREADY.value) == '1':
                         break
 
                 if beat_num == len(data) - 1:
@@ -308,7 +308,7 @@ class AXI4Master(BusDriver):
             # Wait for the response
             while True:
                 await ReadOnly()
-                if self.bus.BVALID.value and self.bus.BREADY.value:
+                if str(self.bus.BVALID.value) == '1' and str(self.bus.BREADY.value) == '1':
                     result = AXIxRESP(self.bus.BRESP.value.integer)
                     break
                 await RisingEdge(self.clock)
@@ -410,7 +410,7 @@ class AXI4Master(BusDriver):
 
             while True:
                 await ReadOnly()
-                if self.bus.ARREADY.value:
+                if str(self.bus.ARREADY.value) == '1':
                     break
                 await RisingEdge(self.clock)
 
@@ -424,7 +424,7 @@ class AXI4Master(BusDriver):
             for beat_num in itertools.count():
                 while True:
                     await ReadOnly()
-                    if self.bus.RVALID.value and self.bus.RREADY.value:
+                    if str(self.bus.RVALID.value) == '1' and str(self.bus.RREADY.value) == '1':
                         # Shift and mask to correctly handle narrow bursts
                         beat_value = shift_and_mask(self.bus.RDATA.value,
                                                     size, byte_offset)
@@ -438,7 +438,7 @@ class AXI4Master(BusDriver):
                         break
                     await RisingEdge(self.clock)
 
-                if not hasattr(self.bus, "RLAST") or self.bus.RLAST.value:
+                if not hasattr(self.bus, "RLAST") or str(self.bus.RLAST.value) == '1':
                     break
 
                 await RisingEdge(self.clock)
@@ -613,7 +613,7 @@ class AXI4Slave(BusDriver):
             while True:
                 self.bus.WREADY.value = 0
                 await ReadOnly()
-                if self.bus.AWVALID.value:
+                if str(self.bus.AWVALID.value) == '1':
                     self.bus.WREADY.value = 1
                     break
                 await clock_re
@@ -643,7 +643,7 @@ class AXI4Slave(BusDriver):
             await clock_re
 
             while True:
-                if self.bus.WVALID.value:
+                if str(self.bus.WVALID.value) == '1':
                     word = self.bus.WDATA.value
                     word.big_endian = self.big_endian
                     _burst_diff = burst_length - burst_count
@@ -661,7 +661,7 @@ class AXI4Slave(BusDriver):
         while True:
             while True:
                 await ReadOnly()
-                if self.bus.ARVALID.value:
+                if str(self.bus.ARVALID.value) == '1':
                     break
                 await clock_re
 
@@ -694,7 +694,7 @@ class AXI4Slave(BusDriver):
             while True:
                 self.bus.RVALID.value = 1
                 await ReadOnly()
-                if self.bus.RREADY.value:
+                if str(self.bus.RREADY.value) == '1':
                     _burst_diff = burst_length - burst_count
                     _st = _araddr + (_burst_diff * bytes_in_beat)
                     _end = _araddr + ((_burst_diff + 1) * bytes_in_beat)

--- a/src/cocotb_bus/drivers/amba.py
+++ b/src/cocotb_bus/drivers/amba.py
@@ -17,6 +17,7 @@ from cocotb.handle import SimHandleBase
 from cocotb.triggers import ClockCycles, Combine, Lock, ReadOnly, RisingEdge
 
 from cocotb_bus.drivers import BusDriver
+from cocotb_bus.compat import coroutine
 
 
 class AXIBurst(enum.IntEnum):
@@ -244,7 +245,7 @@ class AXI4Master(BusDriver):
                 if beat_num == len(data) - 1:
                     self.bus.WVALID.value = 0
 
-    @cocotb.coroutine
+    @coroutine
     async def write(
         self, address: int, value: Union[int, Sequence[int]], *,
         size: Optional[int] = None, burst: AXIBurst = AXIBurst.INCR,
@@ -324,7 +325,7 @@ class AXI4Master(BusDriver):
                     err_msg.format(address, len(value), burst.name,
                                    result.value, result.name), result)
 
-    @cocotb.coroutine
+    @coroutine
     async def read(
         self, address: int, length: int = 1, *,
         size: Optional[int] = None, burst: AXIBurst = AXIBurst.INCR,
@@ -492,7 +493,7 @@ class AXI4LiteMaster(AXI4Master):
 
     _optional_signals = []
 
-    @cocotb.coroutine
+    @coroutine
     async def write(
         self, address: int, value: int, byte_enable: Optional[int] = None,
         address_latency: int = 0, data_latency: int = 0, sync: bool = True
@@ -529,7 +530,7 @@ class AXI4LiteMaster(AXI4Master):
         # Needed for backwards compatibility
         return BinaryValue(value=AXIxRESP.OKAY.value, n_bits=2)
 
-    @cocotb.coroutine
+    @coroutine
     async def read(self, address: int, sync: bool = True) -> BinaryValue:
         """Read from an address.
 

--- a/src/cocotb_bus/drivers/avalon.py
+++ b/src/cocotb_bus/drivers/avalon.py
@@ -357,7 +357,7 @@ class AvalonMemory(BusDriver):
 
             await ReadOnly()
 
-            if self._readable and self.bus.read.value:
+            if self._readable and str(self.bus.read.value) == '1':
                 if not self._burstread:
                     self._pad()
                     addr = self.bus.address.value.integer
@@ -414,7 +414,7 @@ class AvalonMemory(BusDriver):
                         await edge
                         self._do_response()
 
-            if self._writeable and self.bus.write.value:
+            if self._writeable and str(self.bus.write.value) == '1':
                 if not self._burstwrite:
                     addr = self.bus.address.value.integer
                     data = self.bus.writedata.value.integer
@@ -498,7 +498,7 @@ class AvalonST(ValidatedBusDriver):
             FIXME assumes readyLatency of 0
         """
         await ReadOnly()
-        while not self.bus.ready.value:
+        while str(self.bus.ready.value) != '1':
             await RisingEdge(self.clock)
             await ReadOnly()
 
@@ -628,7 +628,7 @@ class AvalonSTPkts(ValidatedBusDriver):
             FIXME assumes readyLatency of 0
         """
         await ReadOnly()
-        while not self.bus.ready.value:
+        while str(self.bus.ready.value) != '1':
             await RisingEdge(self.clock)
             await ReadOnly()
 

--- a/src/cocotb_bus/drivers/avalon.py
+++ b/src/cocotb_bus/drivers/avalon.py
@@ -17,11 +17,11 @@ from typing import Iterable, Union, Optional
 from scapy.utils import hexdump
 
 import cocotb
-from cocotb.decorators import coroutine
 from cocotb.triggers import RisingEdge, FallingEdge, ReadOnly, NextTimeStep
 from cocotb.binary import BinaryValue
 
 from cocotb_bus.drivers import BusDriver, ValidatedBusDriver
+from cocotb_bus.compat import coroutine
 
 
 class AvalonMM(BusDriver):

--- a/src/cocotb_bus/drivers/avalon.py
+++ b/src/cocotb_bus/drivers/avalon.py
@@ -20,7 +20,6 @@ import cocotb
 from cocotb.decorators import coroutine
 from cocotb.triggers import RisingEdge, FallingEdge, ReadOnly, NextTimeStep
 from cocotb.binary import BinaryValue
-from cocotb.result import TestError
 
 from cocotb_bus.drivers import BusDriver, ValidatedBusDriver
 
@@ -100,11 +99,11 @@ class AvalonMaster(AvalonMM):
             The read data value.
 
         Raises:
-            :any:`TestError`: If master is write-only.
+            :any:`AssertionError`: If master is write-only.
         """
         if not self._can_read:
             self.log.error("Cannot read - have no read signal")
-            raise TestError("Attempt to read on a write-only AvalonMaster")
+            raise AssertionError("Attempt to read on a write-only AvalonMaster")
 
         await self._acquire_lock()
 
@@ -161,11 +160,11 @@ class AvalonMaster(AvalonMM):
             value: The data value to write.
 
         Raises:
-            :any:`TestError`: If master is read-only.
+            :any:`AssertionError`: If master is read-only.
         """
         if not self._can_write:
             self.log.error("Cannot write - have no write signal")
-            raise TestError("Attempt to write on a read-only AvalonMaster")
+            raise AssertionError("Attempt to write on a read-only AvalonMaster")
 
         await self._acquire_lock()
 
@@ -248,7 +247,7 @@ class AvalonMemory(BusDriver):
             self._writeable = True
 
         if not self._readable and not self._writeable:
-            raise TestError("Attempt to instantiate useless memory")
+            raise AssertionError("Attempt to instantiate useless memory")
 
         # Allow dual port RAMs by referencing the same dictionary
         if memory is None:
@@ -664,7 +663,7 @@ class AvalonSTPkts(ValidatedBusDriver):
         if hasattr(self.bus, 'channel'):
             self.bus.channel.value = 0
         elif channel is not None:
-            raise TestError("%s does not have a channel signal" % self.name)
+            raise AssertionError("%s does not have a channel signal" % self.name)
 
         while string:
             if not firstword or (firstword and sync):
@@ -688,7 +687,7 @@ class AvalonSTPkts(ValidatedBusDriver):
                 if channel is None:
                     self.bus.channel.value = 0
                 elif channel > self.config['maxChannel'] or channel < 0:
-                    raise TestError("%s: Channel value %d is outside range 0-%d" %
+                    raise AssertionError("%s: Channel value %d is outside range 0-%d" %
                                     (self.name, channel, self.config['maxChannel']))
                 else:
                     self.bus.channel.value = channel

--- a/src/cocotb_bus/drivers/opb.py
+++ b/src/cocotb_bus/drivers/opb.py
@@ -9,11 +9,11 @@ Drivers for On-chip Peripheral Bus.
 NOTE: Currently we only support a very small subset of functionality.
 """
 
-import cocotb
 from cocotb.triggers import RisingEdge, ReadOnly
 from cocotb.binary import BinaryValue
 
 from cocotb_bus.drivers import BusDriver
+from cocotb_bus.compat import coroutine
 
 
 class OPBException(Exception):
@@ -32,7 +32,7 @@ class OPBMaster(BusDriver):
         self.bus.select.setimmediatevalue(0)
         self.log.debug("OPBMaster created")
 
-    @cocotb.coroutine
+    @coroutine
     async def read(self, address: int, sync: bool = True) -> BinaryValue:
         """Issue a request to the bus and block until this comes back.
 
@@ -77,7 +77,7 @@ class OPBMaster(BusDriver):
         self.log.info("Read of address 0x%x returned 0x%08x" % (address, data))
         return data
 
-    @cocotb.coroutine
+    @coroutine
     async def write(self, address: int, value: int, sync: bool = True) -> None:
         """Issue a write to the given address with the specified value.
 

--- a/src/cocotb_bus/monitors/__init__.py
+++ b/src/cocotb_bus/monitors/__init__.py
@@ -17,7 +17,7 @@ import cocotb
 from cocotb.triggers import Event, Timer, First
 
 from cocotb_bus.bus import Bus
-from cocotb_bus.compat import coroutine
+from cocotb_bus.compat import coroutine, set_event
 
 
 class MonitorStatistics:
@@ -51,7 +51,10 @@ class Monitor:
 
     def __init__(self, callback=None, event=None):
         self._event = event
+        if self._event is not None:
+            self._event.data = None  # FIXME: This attribute should be removed on next API break
         self._wait_event = Event()
+        self._wait_event.data = None
         self._recvQ = deque()
         self._callbacks = []
         self.stats = MonitorStatistics()
@@ -134,11 +137,11 @@ class Monitor:
             self._recvQ.append(transaction)
 
         if self._event is not None:
-            self._event.set(data=transaction)
+            set_event(self._event, transaction)
 
         # If anyone was waiting then let them know
         if self._wait_event is not None:
-            self._wait_event.set(data=transaction)
+            set_event(self._wait_event, transaction)
             self._wait_event.clear()
 
 

--- a/src/cocotb_bus/monitors/__init__.py
+++ b/src/cocotb_bus/monitors/__init__.py
@@ -11,10 +11,10 @@ the transactions.
 """
 
 from collections import deque
+import logging
 
 import cocotb
 from cocotb.decorators import coroutine
-from cocotb.log import SimLog
 from cocotb.triggers import Event, Timer, First
 
 from cocotb_bus.bus import Bus
@@ -58,7 +58,7 @@ class Monitor:
 
         # Sub-classes may already set up logging
         if not hasattr(self, "log"):
-            self.log = SimLog("cocotb.monitor.%s" % (type(self).__qualname__))
+            self.log = logging.getLogger("cocotb.monitor.%s" % (type(self).__qualname__))
 
         if callback is not None:
             self.add_callback(callback)
@@ -149,7 +149,7 @@ class BusMonitor(Monitor):
 
     def __init__(self, entity, name, clock, reset=None, reset_n=None,
                  callback=None, event=None, **kwargs):
-        self.log = SimLog("cocotb.%s.%s" % (entity._name, name))
+        self.log = logging.getLogger("cocotb.%s.%s" % (entity._name, name))
         self.entity = entity
         self.name = name
         self.clock = clock

--- a/src/cocotb_bus/monitors/__init__.py
+++ b/src/cocotb_bus/monitors/__init__.py
@@ -14,10 +14,10 @@ from collections import deque
 import logging
 
 import cocotb
-from cocotb.decorators import coroutine
 from cocotb.triggers import Event, Timer, First
 
 from cocotb_bus.bus import Bus
+from cocotb_bus.compat import coroutine
 
 
 class MonitorStatistics:

--- a/src/cocotb_bus/monitors/avalon.py
+++ b/src/cocotb_bus/monitors/avalon.py
@@ -53,8 +53,8 @@ class AvalonST(BusMonitor):
 
         def valid():
             if hasattr(self.bus, "ready"):
-                return self.bus.valid.value and self.bus.ready.value
-            return self.bus.valid.value
+                return str(self.bus.valid.value) == '1' and str(self.bus.ready.value) == '1'
+            return str(self.bus.valid.value) == '1'
 
         # NB could await on valid here more efficiently?
         while True:
@@ -136,8 +136,8 @@ class AvalonSTPkts(BusMonitor):
 
         def valid():
             if hasattr(self.bus, 'ready'):
-                return self.bus.valid.value and self.bus.ready.value
-            return self.bus.valid.value
+                return str(self.bus.valid.value) == '1' and str(self.bus.ready.value) == '1'
+            return str(self.bus.valid.value) == '1'
 
         while True:
             await clkedge
@@ -148,7 +148,7 @@ class AvalonSTPkts(BusMonitor):
             if valid():
                 invalid_cyclecount = 0
 
-                if self.bus.startofpacket.value:
+                if str(self.bus.startofpacket.value) == '1':
                     if pkt:
                         raise AvalonProtocolError("Duplicate start-of-packet received on %s" %
                                                   str(self.bus.startofpacket))
@@ -161,7 +161,7 @@ class AvalonSTPkts(BusMonitor):
 
                 # Handle empty and X's in empty / data
                 vec = BinaryValue()
-                if not self.bus.endofpacket.value:
+                if str(self.bus.endofpacket.value) != '1':
                     vec = self.bus.data.value
                 else:
                     value = self.bus.data.value.get_binstr()
@@ -189,7 +189,7 @@ class AvalonSTPkts(BusMonitor):
                     elif self.bus.channel.value.integer != channel:
                         raise AvalonProtocolError("Channel value changed during packet")
 
-                if self.bus.endofpacket.value:
+                if str(self.bus.endofpacket.value) == '1':
                     self.log.info("Received a packet of %d bytes", len(pkt))
                     self.log.debug(f"Received Packet:\n{hexdump(pkt, dump=True)}")
                     self.channel = channel

--- a/src/cocotb_bus/scoreboard.py
+++ b/src/cocotb_bus/scoreboard.py
@@ -8,7 +8,6 @@
 
 import logging
 
-from cocotb.log import SimLog
 from cocotb.result import TestSuccess
 
 from cocotb_bus.monitors import Monitor
@@ -39,7 +38,7 @@ class Scoreboard:
 
     def __init__(self, dut, reorder_depth=0, fail_immediately=True):  # FIXME: reorder_depth needed here?
         self.dut = dut
-        self.log = SimLog("cocotb.scoreboard.%s" % self.dut._name)
+        self.log = logging.getLogger("cocotb.scoreboard.%s" % self.dut._name)
         self.errors = 0
         self.expected = {}
         self._imm = fail_immediately

--- a/tests/test_cases/test_array_buses/test_array_buses.py
+++ b/tests/test_cases/test_array_buses/test_array_buses.py
@@ -39,7 +39,7 @@ class TestMonitor(BusMonitor):
         clkedge = RisingEdge(self.clock)
         while True:
             await clkedge
-            if self.bus.valid.value:
+            if str(self.bus.valid.value) == '1':
                 self._recv(int(self.bus.data.value))
 
     def _get_result(self, transaction):

--- a/tests/test_cases/test_array_buses/test_array_buses.py
+++ b/tests/test_cases/test_array_buses/test_array_buses.py
@@ -40,7 +40,7 @@ class TestMonitor(BusMonitor):
         while True:
             await clkedge
             if self.bus.valid.value:
-                self._recv(int(self.bus.data))
+                self._recv(int(self.bus.data.value))
 
     def _get_result(self, transaction):
         self.log.info("Received {} on bank {}".format(transaction, self.bank))

--- a/tests/test_cases/test_avalon/test_avalon.py
+++ b/tests/test_cases/test_avalon/test_avalon.py
@@ -34,7 +34,6 @@ Also used as regression test of cocotb capabilities
 import cocotb
 from cocotb.triggers import Timer, RisingEdge
 from cocotb.clock import Clock
-from cocotb.result import TestFailure
 from cocotb_bus.drivers.avalon import AvalonMemory
 
 
@@ -110,10 +109,10 @@ async def test_burst_read(dut):
                 memdictvalue = "Error"
             else:
                 memdictvalue = hex(memdictvalue)
-            raise TestFailure("Wrong value read in memory :" +
-                              " read_mem[" + hex(key) + "] = " +
-                              hex(value) + " must be " +
-                              memdictvalue)
+            assert False, (
+                "Wrong value read in memory : read_mem[" + hex(key) + "] = " +
+                hex(value) + " must be " + memdictvalue
+            )
 
     await Timer(1, "ns")
     dut.user_read_buffer.value = 0

--- a/tests/test_cases/test_axi4/test_axi4.py
+++ b/tests/test_cases/test_axi4/test_axi4.py
@@ -8,11 +8,12 @@
 from random import randint, randrange, getrandbits
 
 from packaging.version import parse as parse_version
+import warnings
 
 import cocotb
 from cocotb.clock import Clock
-from cocotb.regression import TestFactory
 from cocotb.triggers import ClockCycles, Combine, Join, RisingEdge
+from cocotb_bus.compat import TestFactory
 from cocotb_bus.drivers.amba import (
     AXIBurst, AXI4LiteMaster, AXI4Master, AXIProtocolError, AXIReadBurstLengthMismatch,
     AXIxRESP)
@@ -519,7 +520,9 @@ single_beat_with_latency = TestFactory(test_single_beat)
 single_beat_with_latency.add_option('driver', (AXI4Master,))
 single_beat_with_latency.add_option('address_latency', (0, 5))
 single_beat_with_latency.add_option('data_latency', (1, 10))
-single_beat_with_latency.generate_tests(postfix="_latency")
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    single_beat_with_latency.generate_tests(postfix="_latency")
 
 incr_burst = TestFactory(test_incr_burst)
 incr_burst.add_option('return_rresp', (True, False))
@@ -529,7 +532,9 @@ incr_burst.generate_tests()
 incr_burst_size = TestFactory(test_incr_burst)
 incr_burst_size.add_option('return_rresp', (False,))
 incr_burst_size.add_option('size', (1, 2))
-incr_burst_size.generate_tests(postfix="_size")
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    incr_burst_size.generate_tests(postfix="_size")
 
 fixed_wrap_burst = TestFactory(test_fixed_wrap_burst)
 fixed_wrap_burst.add_option('size', (None, 1, 2))

--- a/tests/test_cases/test_case_insensitive/case_insensitive.py
+++ b/tests/test_cases/test_case_insensitive/case_insensitive.py
@@ -72,7 +72,7 @@ class TestMonitor(BusMonitor):
             if not self.bus.valid.value:
                 continue
             # Receive transaction and provide to _recv method
-            tr = TestTransaction(int(self.bus.data), int(self.bus.tmp))
+            tr = TestTransaction(int(self.bus.data.value), int(self.bus.tmp.value))
             self._recv(tr)
 
     def _get_result(self, transaction):

--- a/tests/test_cases/test_case_insensitive/case_insensitive.py
+++ b/tests/test_cases/test_case_insensitive/case_insensitive.py
@@ -69,7 +69,7 @@ class TestMonitor(BusMonitor):
         clkedge = RisingEdge(self.clock)
         while True:
             await clkedge
-            if not self.bus.valid.value:
+            if str(self.bus.valid.value) != '1':
                 continue
             # Receive transaction and provide to _recv method
             tr = TestTransaction(int(self.bus.data.value), int(self.bus.tmp.value))


### PR DESCRIPTION
This PR removes uses of a few things that have been deprecated or removed in the upcoming cocotb 2.0 release.

The changes either do not change the API of cocotb-bus or change it in a way that few, if any users will be affected. The commit messages have more detailed explanations of rationale where the lack of impact wasn't obvious.

I hope that it will be possible to have a single code base seamlessly supporting both pre-2.0 cocotb and post-2.0 cocotb. This should significantly reduce the pain of migration to cocotb-bus users as it's one less thing to worry about.