### PR TITLE
Fix compatibility with upcoming cocotb 2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.12"]
         # NOTE: align with versions in noxfile.py:
-        cocotb-version: ["1.6.0", "1.9.0", "github-828d127e"]
+        cocotb-version: ["1.6.0", "1.9.0", "github-b9dd5ee1"]
         include:
         - sim: icarus
           sim-version: apt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.12"]
         # NOTE: align with versions in noxfile.py:
-        cocotb-version: ["1.6.0", "1.9.0"]
+        cocotb-version: ["1.6.0", "1.9.0", "github-828d127e"]
         include:
         - sim: icarus
           sim-version: apt

--- a/examples/dff/tests/dff_cocotb.py
+++ b/examples/dff/tests/dff_cocotb.py
@@ -31,9 +31,8 @@ import warnings
 import cocotb
 from cocotb.clock import Clock
 from cocotb.triggers import ReadOnly, RisingEdge
-from cocotb.binary import BinaryValue
 
-from cocotb_bus.compat import TestFactory
+from cocotb_bus.compat import create_binary, TestFactory
 from cocotb_bus.monitors import Monitor
 from cocotb_bus.drivers import BitDriver
 from cocotb_bus.scoreboard import Scoreboard
@@ -138,7 +137,7 @@ async def run_test(dut):
 
     cocotb.start_soon(Clock(dut.c, 10, 'us').start(start_high=False))
 
-    tb = DFF_TB(dut, init_val=BinaryValue("0"))
+    tb = DFF_TB(dut, init_val=create_binary("0", 1, big_endian=True))
 
     clkedge = RisingEdge(dut.c)
 
@@ -159,5 +158,6 @@ async def run_test(dut):
 
 
 # Register the test.
+
 factory = TestFactory(run_test)
 factory.generate_tests()

--- a/examples/endian_swapper/tests/test_endian_swapper.py
+++ b/examples/endian_swapper/tests/test_endian_swapper.py
@@ -35,7 +35,7 @@ import cocotb
 
 from cocotb.clock import Clock
 from cocotb.triggers import Timer, RisingEdge, ReadOnly
-from cocotb_bus.compat import TestFactory
+from cocotb_bus.compat import TestFactory, convert_binary_to_unsigned
 from cocotb_bus.drivers import BitDriver
 from cocotb_bus.drivers.avalon import AvalonSTPkts as AvalonSTDriver
 from cocotb_bus.drivers.avalon import AvalonMaster
@@ -223,8 +223,12 @@ async def run_test(dut, data_in=None, config_coroutine=None, idle_inserter=None,
 
     pkt_count = await tb.csr.read(1)
 
-    assert pkt_count.integer == tb.pkts_sent, "DUT recorded %d packets but tb counted %d" % (pkt_count.integer, tb.pkts_sent)
-    dut._log.info("DUT correctly counted %d packets" % pkt_count.integer)
+    assert convert_binary_to_unsigned(pkt_count) == tb.pkts_sent, (
+        "DUT recorded %d packets but tb counted %d" % (
+            convert_binary_to_unsigned(pkt_count), tb.pkts_sent
+        )
+    )
+    dut._log.info("DUT correctly counted %d packets" % convert_binary_to_unsigned(pkt_count))
 
     raise tb.scoreboard.result
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,9 +2,13 @@ import nox
 
 
 @nox.session
-@nox.parametrize("cocotb", ["1.6.0", "1.9.0"])
+@nox.parametrize("cocotb", ["1.6.0", "1.9.0", "github-828d127e"])
 def tests(session, cocotb):
-    session.install("pytest", "coverage", f"cocotb=={cocotb}")
+    if cocotb.startswith("github-"):
+        cocotb_req = "git+https://github.com/cocotb/cocotb@" + cocotb[len("github-"):]
+    else:
+        cocotb_req = f"cocotb=={cocotb}"
+    session.install("pytest", "coverage", cocotb_req)
     session.install(".")
     session.run("make", external=True)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,7 +2,7 @@ import nox
 
 
 @nox.session
-@nox.parametrize("cocotb", ["1.6.0", "1.9.0", "github-828d127e"])
+@nox.parametrize("cocotb", ["1.6.0", "1.9.0", "github-b9dd5ee1"])
 def tests(session, cocotb):
     if cocotb.startswith("github-"):
         cocotb_req = "git+https://github.com/cocotb/cocotb@" + cocotb[len("github-"):]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         packages=find_packages("src"),
         package_dir={"": "src"},
         install_requires=[
-            "cocotb>=1.6.0,<2.0",
+            "cocotb>=1.6.0",
             "scapy",
         ],
         python_requires='>=3.6'

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
         install_requires=[
             "cocotb>=1.6.0",
             "scapy",
+            "packaging",
         ],
         python_requires='>=3.6'
     )

--- a/src/cocotb_bus/compat.py
+++ b/src/cocotb_bus/compat.py
@@ -78,15 +78,12 @@ else:
     from cocotb.binary import BinaryValue
     from cocotb.binary import _RESOLVE_TO_CHOICE
 
+    coroutine = cocotb.coroutine
     BinaryType = BinaryValue
 
 
     def set_event(event, data):
         event.set(data)
-
-
-    def coroutine(f):
-        return cocotb.coroutine(f)
 
 
     def create_binary(binstr: Union[int, str, bytes, BinaryValue], bit_count: int,

--- a/src/cocotb_bus/compat.py
+++ b/src/cocotb_bus/compat.py
@@ -4,6 +4,7 @@
 
 
 from packaging.version import parse as parse_version
+from typing import Optional, Union
 import warnings
 
 import cocotb
@@ -15,7 +16,12 @@ def TestFactory(*args, **kwargs):
         return cocotb.regression.TestFactory(*args, **kwargs)
 
 
-if parse_version(cocotb.__version__) > parse_version("2.dev0"):
+cocotb_2x_or_newer = parse_version(cocotb.__version__) > parse_version("2.dev0")
+if cocotb_2x_or_newer:
+    from cocotb.types import LogicArray, Range
+    BinaryType = LogicArray
+
+
     def set_event(event, data):
         event.data = data
         event.set()
@@ -23,9 +29,94 @@ if parse_version(cocotb.__version__) > parse_version("2.dev0"):
     def coroutine(f):
         return f
 
+
+    def create_binary(binstr: Union[int, str, bytes, LogicArray], bit_count: int, big_endian: bool):
+        if big_endian:
+            range=Range(0, 'to', bit_count - 1)
+        else:
+            range=Range(bit_count - 1, 'downto', 0)
+
+        if isinstance(binstr, bytes):
+            if not big_endian:
+                binstr = reversed(binstr)
+            binstr = "".join([format(char, "08b") for char in binstr])
+
+            if big_endian:
+                binstr = binstr + "0" * (bit_count - len(binstr))
+            else:
+                binstr = "0" * (bit_count - len(binstr)) + binstr
+
+        return LogicArray(binstr, range=range)
+
+
+    def create_binary_from_other(value: BinaryType, binstr: Union[int, str, bytes]):
+        return LogicArray(value=binstr, range=value.range)
+
+
+    def convert_binary_to_bytes(value: BinaryType, big_endian: bool):
+        return value.to_bytes('big' if big_endian else 'little')
+
+
+    def convert_binary_to_unsigned(value: Union[int, BinaryType]):
+        if isinstance(value, int):
+            return value
+        return value.to_unsigned()
+
+
+    def binary_slice(value: BinaryType, start: int, end: int):
+        # On 2.x the default slice direction is downto, whereas on 1.9.x it's to
+        # Additionally, in the case of BinaryValue slices always operate within 0..len(v) index
+        # range regardless of how BinaryValue was acquired. In the case of LogicArray slices
+        # operate on its range which doesn't necessarily start at zero. E.g. the following
+        # returns top 8 bits: LogicArray(..., Range(31, 'downto', 0))[31:15][31:20][31:24]
+        offset = min(value.range.left, value.range.right)
+        start = len(value) - start - 1 + offset
+        end = len(value) - end - 1 + offset
+        return value[start:end]
+
 else:
+    from cocotb.binary import BinaryValue
+    from cocotb.binary import _RESOLVE_TO_CHOICE
+
+    BinaryType = BinaryValue
+
+
     def set_event(event, data):
         event.set(data)
 
+
     def coroutine(f):
         return cocotb.coroutine(f)
+
+
+    def create_binary(binstr: Union[int, str, bytes, BinaryValue], bit_count: int,
+                      big_endian: bool):
+        return BinaryValue(value=binstr, n_bits=bit_count, bigEndian=big_endian)
+
+
+    def create_binary_from_other(value: BinaryType, binstr: Union[int, str, bytes]):
+        return BinaryValue(value=binstr, n_bits=value.n_bits, bigEndian=value.big_endian)
+
+
+    def convert_binary_to_bytes(value: BinaryType, big_endian: bool):
+        # Setting bigEndian does not affect initialization because value.binstr already is adjusted
+        # to contain n_bits number of bits. Only access via buff is affected.
+        value = BinaryValue(value=value.binstr, n_bits=value.n_bits, bigEndian=big_endian)
+        return value.buff
+
+
+    def convert_binary_to_unsigned(value: Union[int, BinaryType]):
+        # In 1.9.x code has more automatic conversions, therefore code does not consistently
+        # apply .integer
+        if isinstance(value, int):
+            return value
+        return value.integer
+
+
+    def binary_slice(value: BinaryType, start: int, end: int):
+        # On 2.x the default slice direction is downto, whereas on 1.9.x it's to
+        return value[start:end]
+
+
+def binary_is_resolvable(value: BinaryType):
+    return value.is_resolvable

--- a/src/cocotb_bus/drivers/__init__.py
+++ b/src/cocotb_bus/drivers/__init__.py
@@ -16,7 +16,7 @@ from cocotb.triggers import (Event, RisingEdge, ReadOnly, NextTimeStep,
 from cocotb.handle import SimHandleBase
 
 from cocotb_bus.bus import Bus
-from cocotb_bus.compat import coroutine
+from cocotb_bus.compat import coroutine, convert_binary_to_unsigned
 
 
 class BitDriver:
@@ -260,7 +260,7 @@ class BusDriver(Driver):
         registering more callbacks can occur.
         """
         await ReadOnly()
-        while signal.value.integer != 1:
+        while convert_binary_to_unsigned(signal.value) != 1:
             await RisingEdge(signal)
             await ReadOnly()
         await NextTimeStep()
@@ -274,7 +274,7 @@ class BusDriver(Driver):
         registering more callbacks can occur.
         """
         await ReadOnly()
-        while signal.value.integer != 0:
+        while convert_binary_to_unsigned(signal.value) != 0:
             await Edge(signal)
             await ReadOnly()
         await NextTimeStep()

--- a/src/cocotb_bus/drivers/amba.py
+++ b/src/cocotb_bus/drivers/amba.py
@@ -71,12 +71,12 @@ class AXI4Master(BusDriver):
                  **kwargs: Any):
         BusDriver.__init__(self, entity, name, clock, **kwargs)
 
-        # Drive some sensible defaults (setimmediatevalue to avoid x asserts)
-        self.bus.AWVALID.setimmediatevalue(0)
-        self.bus.WVALID.setimmediatevalue(0)
-        self.bus.ARVALID.setimmediatevalue(0)
-        self.bus.BREADY.setimmediatevalue(1)
-        self.bus.RREADY.setimmediatevalue(1)
+        # Drive some sensible defaults
+        self.bus.AWVALID.value = 0
+        self.bus.WVALID.value = 0
+        self.bus.ARVALID.value = 0
+        self.bus.BREADY.value = 1
+        self.bus.RREADY.value = 1
 
         # Set the default value (0) for the unsupported signals, which
         # translate to:
@@ -91,7 +91,7 @@ class AXI4Master(BusDriver):
             "ARID", "ARREGION", "ARLOCK", "ARCACHE", "ARPROT", "ARQOS"]
         for signal in unsupported_signals:
             try:
-                getattr(self.bus, signal).setimmediatevalue(0)
+                getattr(self.bus, signal).value = 0
             except AttributeError:
                 pass
 
@@ -596,10 +596,10 @@ class AXI4Slave(BusDriver):
         self.clock = clock
 
         self.big_endian = big_endian
-        self.bus.ARREADY.setimmediatevalue(1)
-        self.bus.RVALID.setimmediatevalue(0)
-        self.bus.RLAST.setimmediatevalue(0)
-        self.bus.AWREADY.setimmediatevalue(1)
+        self.bus.ARREADY.value = 1
+        self.bus.RVALID.value = 0
+        self.bus.RLAST.value = 0
+        self.bus.AWREADY.value = 1
         self._memory = memory
 
         self.write_address_busy = Lock("%s_wabusy" % name)

--- a/src/cocotb_bus/drivers/avalon.py
+++ b/src/cocotb_bus/drivers/avalon.py
@@ -49,25 +49,25 @@ class AvalonMM(BusDriver):
         self._can_read = False
         self._can_write = False
 
-        # Drive some sensible defaults (setimmediatevalue to avoid x asserts)
+        # Drive some sensible defaults
         if hasattr(self.bus, "read"):
-            self.bus.read.setimmediatevalue(0)
+            self.bus.read.value = 0
             self._can_read = True
 
         if hasattr(self.bus, "write"):
-            self.bus.write.setimmediatevalue(0)
+            self.bus.write.value = 0
             self.bus.writedata.value = create_binary_from_other(self.bus.writedata.value,
                                                                 "x" * len(self.bus.writedata))
             self._can_write = True
 
         if hasattr(self.bus, "byteenable"):
-            self.bus.byteenable.setimmediatevalue(0)
+            self.bus.byteenable.value = 0
 
         if hasattr(self.bus, "cs"):
-            self.bus.cs.setimmediatevalue(0)
+            self.bus.cs.value = 0
 
-        self.bus.address.setimmediatevalue(create_binary_from_other(self.bus.address.value,
-                                                                    "x" * len(self.bus.address)))
+        self.bus.address.value = create_binary_from_other(self.bus.address.value,
+                                                          "x" * len(self.bus.address))
 
     def read(self, address):
         pass
@@ -260,10 +260,10 @@ class AvalonMemory(BusDriver):
         self._coro = cocotb.start_soon(self._respond())
 
         if hasattr(self.bus, "readdatavalid"):
-            self.bus.readdatavalid.setimmediatevalue(0)
+            self.bus.readdatavalid.value = 0
 
         if hasattr(self.bus, "waitrequest"):
-            self.bus.waitrequest.setimmediatevalue(0)
+            self.bus.waitrequest.value = 0
 
         if hasattr(self.bus, "burstcount"):
             if hasattr(self.bus, "readdatavalid"):
@@ -275,7 +275,7 @@ class AvalonMemory(BusDriver):
                 self.bus.waitrequest.value = 0
 
         if hasattr(self.bus, "readdatavalid"):
-            self.bus.readdatavalid.setimmediatevalue(0)
+            self.bus.readdatavalid.value = 0
 
     def _pad(self):
         """Pad response queue up to read latency."""

--- a/src/cocotb_bus/drivers/opb.py
+++ b/src/cocotb_bus/drivers/opb.py
@@ -28,7 +28,7 @@ class OPBMaster(BusDriver):
 
     def __init__(self, entity, name, clock, **kwargs):
         BusDriver.__init__(self, entity, name, clock, **kwargs)
-        self.bus.select.setimmediatevalue(0)
+        self.bus.select.value = 0
         self.log.debug("OPBMaster created")
 
     @coroutine

--- a/src/cocotb_bus/drivers/opb.py
+++ b/src/cocotb_bus/drivers/opb.py
@@ -10,10 +10,9 @@ NOTE: Currently we only support a very small subset of functionality.
 """
 
 from cocotb.triggers import RisingEdge, ReadOnly
-from cocotb.binary import BinaryValue
 
 from cocotb_bus.drivers import BusDriver
-from cocotb_bus.compat import coroutine
+from cocotb_bus.compat import BinaryType, coroutine
 
 
 class OPBException(Exception):
@@ -33,7 +32,7 @@ class OPBMaster(BusDriver):
         self.log.debug("OPBMaster created")
 
     @coroutine
-    async def read(self, address: int, sync: bool = True) -> BinaryValue:
+    async def read(self, address: int, sync: bool = True) -> BinaryType:
         """Issue a request to the bus and block until this comes back.
 
         Simulation time still progresses but syntactically it blocks.

--- a/src/cocotb_bus/drivers/xgmii.py
+++ b/src/cocotb_bus/drivers/xgmii.py
@@ -11,10 +11,10 @@ import zlib
 from scapy.utils import hexdump
 
 from cocotb.triggers import RisingEdge
-from cocotb.binary import BinaryValue
 from cocotb.handle import SimHandleBase
 
 from cocotb_bus.drivers import Driver
+from cocotb_bus.compat import create_binary
 
 _XGMII_IDLE      = 0x07  # noqa
 _XGMII_START     = 0xFB  # noqa
@@ -54,7 +54,6 @@ class _XGMIIBus:
                 byte plus a control bit per byte in the MSBs.
         """
 
-        self._value = BinaryValue(n_bits=nbytes*9, bigEndian=False)
         self._integer = 0
         self._interleaved = interleaved
         self._nbytes = nbytes
@@ -76,8 +75,6 @@ class _XGMIIBus:
             self._integer |= (byte << (index * 8))
             self._integer |= (int(ctrl) << (self._nbytes*8 + index))
 
-        self._value.integer = self._integer
-
     @property
     def value(self):
         """Get the integer representation of this data word suitable for driving
@@ -85,9 +82,9 @@ class _XGMIIBus:
 
         NB clears the value.
         """
-        self._value.integer = self._integer
+        value = create_binary(self._integer, self._nbytes * 9, big_endian=False)
         self._integer = 0
-        return self._value
+        return value
 
     def __len__(self):
         return self._nbytes

--- a/src/cocotb_bus/monitors/__init__.py
+++ b/src/cocotb_bus/monitors/__init__.py
@@ -17,7 +17,7 @@ import cocotb
 from cocotb.triggers import Event, Timer, First
 
 from cocotb_bus.bus import Bus
-from cocotb_bus.compat import coroutine, set_event
+from cocotb_bus.compat import coroutine, convert_binary_to_unsigned, set_event
 
 
 class MonitorStatistics:
@@ -166,9 +166,9 @@ class BusMonitor(Monitor):
     def in_reset(self):
         """Boolean flag showing whether the bus is in reset state or not."""
         if self._reset_n is not None:
-            return not bool(self._reset_n.value.integer)
+            return not bool(convert_binary_to_unsigned(self._reset_n.value))
         if self._reset is not None:
-            return bool(self._reset.value.integer)
+            return bool(convert_binary_to_unsigned(self._reset.value))
         return False
 
     def __str__(self):

--- a/src/cocotb_bus/monitors/xgmii.py
+++ b/src/cocotb_bus/monitors/xgmii.py
@@ -19,6 +19,7 @@ from scapy.utils import hexdump
 
 from cocotb.triggers import RisingEdge
 
+from cocotb_bus.compat import convert_binary_to_unsigned
 from cocotb_bus.monitors import Monitor
 
 _XGMII_IDLE      = 0x07  # noqa
@@ -67,7 +68,7 @@ class XGMII(Monitor):
 
         Returns a tuple of lists.
         """
-        value = self.signal.value.integer
+        value = convert_binary_to_unsigned(self.signal.value)
         bytes = []
         ctrls = []
         byte_shift = 8


### PR DESCRIPTION
This PR fixes remaining issues that prevented compatibility with cocotb 2.0, mostly BinaryValue -> LogicArray migration.

CI for cocotb 2.0 has been enabled and compatibility with cocotb 2.0 has been declared in setup.py.

Note that latest cocotb master doesn't work due to https://github.com/cocotb/cocotb/commit/bfd811bbeba4c7dcc045beeb5c78f8e4901c8364 breaking something.