### PR TITLE
Add support for nameless Avalon ST and MM drivers and monitors

### DIFF
--- a/src/cocotb_bus/drivers/avalon.py
+++ b/src/cocotb_bus/drivers/avalon.py
@@ -28,6 +28,7 @@ from cocotb_bus.compat import (
     coroutine,
 )
 
+from typing import Optional
 
 class AvalonMM(BusDriver):
     """Avalon Memory Mapped Interface (Avalon-MM) Driver.
@@ -474,7 +475,7 @@ class AvalonST(ValidatedBusDriver):
 
     _default_config = {"firstSymbolInHighOrderBits" : True}
 
-    def __init__(self, entity, name, clock, *, config={}, **kwargs):
+    def __init__(self, entity, clock, *, name: Optional[str] = None, config={}, **kwargs):
         ValidatedBusDriver.__init__(self, entity, name, clock, **kwargs)
 
         self.config = AvalonST._default_config.copy()
@@ -565,7 +566,7 @@ class AvalonSTPkts(ValidatedBusDriver):
         "readyLatency"                  : 0
     }
 
-    def __init__(self, entity, name, clock, *, config={}, **kwargs):
+    def __init__(self, entity, clock, *, name: Optional[str] = None, config={}, **kwargs):
         ValidatedBusDriver.__init__(self, entity, name, clock, **kwargs)
 
         self.config = AvalonSTPkts._default_config.copy()

--- a/src/cocotb_bus/drivers/avalon.py
+++ b/src/cocotb_bus/drivers/avalon.py
@@ -12,7 +12,7 @@ NB Currently we only support a very small subset of functionality
 """
 
 import random
-from typing import Iterable, Union, Optional
+from typing import Iterable, Union, Optional, List, Dict
 
 from scapy.utils import hexdump
 
@@ -45,7 +45,7 @@ class AvalonMM(BusDriver):
                          "writedata", "readdatavalid", "byteenable",
                          "cs"]
 
-    def __init__(self, entity, name, clock, **kwargs):
+    def __init__(self, entity, clock, name: Optional[str] = None, **kwargs):
         BusDriver.__init__(self, entity, name, clock, **kwargs)
         self._can_read = False
         self._can_write = False
@@ -80,7 +80,7 @@ class AvalonMM(BusDriver):
 class AvalonMaster(AvalonMM):
     """Avalon Memory Mapped Interface (Avalon-MM) Master."""
 
-    def __init__(self, entity, name, clock, **kwargs):
+    def __init__(self, entity, clock, name: Optional[str] = None, **kwargs):
         AvalonMM.__init__(self, entity, name, clock, **kwargs)
         self.log.debug("AvalonMaster created")
 
@@ -212,7 +212,7 @@ class AvalonMemory(BusDriver):
         "MaxWaitReqLen": 4,  # maximum value of waitrequest
     }
 
-    def __init__(self, entity, name, clock, readlatency_min=1,
+    def __init__(self, entity, clock, name: Optional[str] = None, readlatency_min=1,
                  readlatency_max=1, memory=None, avl_properties={}, **kwargs):
         BusDriver.__init__(self, entity, name, clock, **kwargs)
 
@@ -466,6 +466,14 @@ class AvalonMemory(BusDriver):
                     if self._avalon_properties.get("WriteBurstWaitReq", True):
                         self.bus.waitrequest.value = 1
 
+    def count_mem(self):
+        if isinstance(self._mem, Union[Dict, List]):
+            return len(self._mem)
+        else:
+            self.log.error("Only supports dictionary or lists as memories.")
+
+    def read_mem(self):
+        return self._mem
 
 class AvalonST(ValidatedBusDriver):
     """Avalon Streaming Interface (Avalon-ST) Driver"""

--- a/src/cocotb_bus/monitors/avalon.py
+++ b/src/cocotb_bus/monitors/avalon.py
@@ -25,6 +25,7 @@ from cocotb_bus.compat import (
 )
 from cocotb_bus.monitors import BusMonitor
 
+from typing import Optional
 
 class AvalonProtocolError(Exception):
     pass
@@ -41,7 +42,7 @@ class AvalonST(BusMonitor):
 
     _default_config = {"firstSymbolInHighOrderBits": True}
 
-    def __init__(self, entity, name, clock, *, config={}, **kwargs):
+    def __init__(self, entity, clock, *, name: Optional[str] = None, config={}, **kwargs):
         BusMonitor.__init__(self, entity, name, clock, **kwargs)
 
         self.config = self._default_config.copy()
@@ -92,7 +93,7 @@ class AvalonSTPkts(BusMonitor):
         "invalidTimeout"                : 0,
     }
 
-    def __init__(self, entity, name, clock, *, config={}, report_channel=False, **kwargs):
+    def __init__(self, entity, clock, *, name: Optional[str] = None, config={}, report_channel=False, **kwargs):
         BusMonitor.__init__(self, entity, name , clock, **kwargs)
 
         self.config = self._default_config.copy()
@@ -149,6 +150,10 @@ class AvalonSTPkts(BusMonitor):
             await clkedge
 
             if self.in_reset:
+                pkt = b""
+                in_pkt = False
+                invalid_cyclecount = 0
+                channel = None
                 continue
 
             if valid():


### PR DESCRIPTION
Current implementation expects a name to be provided that is then scanned according to the protocol signals ('ready', 'valid', etc). Both Monitor and BusDriver support for nameless modules that are instead taken from the hierarchy. Ideal when using SystemVerilog Interfaces.

Additionally I include the commit from [Losiek:feature/AvalonSTPkts_reset](https://github.com/cocotb/cocotb-bus/pull/50). 